### PR TITLE
Removing the master/slave vocabulary

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,8 +37,8 @@ source_suffix = ".rst"
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = "index"
+# The main toctree document.
+main_doc = "index"
 
 # General information about the project.
 project = u"pypipegraph"

--- a/pypipegraph/job.py
+++ b/pypipegraph/job.py
@@ -182,7 +182,7 @@ class Job(object):
             self.stderr = None
             self.exception = None
             self.was_run = False
-            self.was_done_on = set()  # on which slave(s) was this job run?
+            self.was_done_on = set()  # on which subordinate(s) was this job run?
             self.was_loaded = False
             self.was_invalidated = False
             self.invalidation_count = (
@@ -312,8 +312,8 @@ class Job(object):
             "Called load() on a j'ob that had is_loadable, but did not overwrite load() as it should"
         )
 
-    def runs_in_slave(self):
-        """Is this a job that runs in our slave, ie. in a spawned job"""
+    def runs_in_subordinate(self):
+        """Is this a job that runs in our subordinate, ie. in a spawned job"""
         return True
 
     def modifies_jobgraph(self):
@@ -455,7 +455,7 @@ class _InvariantJob(Job):
     def depends_on(self, job_joblist_or_list_of_jobs):
         raise ppg_exceptions.JobContractError("Invariants can't have dependencies")
 
-    def runs_in_slave(self):
+    def runs_in_subordinate(self):
         return False
 
 
@@ -1170,7 +1170,7 @@ class MultiFileGeneratingJob(FileGeneratingJob):
                 % (self.job_id, "\n".join(missing_files))
             )
 
-    def runs_in_slave(self):
+    def runs_in_subordinate(self):
         return True
 
 
@@ -1194,7 +1194,7 @@ class TempFileGeneratingJob(FileGeneratingJob):
         except (OSError, IOError):
             pass
 
-    def runs_in_slave(self):
+    def runs_in_subordinate(self):
         return True
 
     def calc_is_done(self, depth=0):
@@ -1313,7 +1313,7 @@ class MultiTempFileGeneratingJob(FileGeneratingJob):
                 % (self.job_id, "\n".join(missing_files))
             )
 
-    def runs_in_slave(self):
+    def runs_in_subordinate(self):
         return True
 
     def calc_is_done(self, depth=0):
@@ -1359,7 +1359,7 @@ class TempFilePlusGeneratingJob(FileGeneratingJob):
         except (OSError, IOError):
             pass
 
-    def runs_in_slave(self):
+    def runs_in_subordinate(self):
         return True
 
     def calc_is_done(self, depth=0):
@@ -1398,7 +1398,7 @@ class TempFilePlusGeneratingJob(FileGeneratingJob):
 
 
 class DataLoadingJob(Job):
-    """Modify the current (system local) master process with a callback function.
+    """Modify the current (system local) main process with a callback function.
     No cleanup is performed - use AttributeLoadingJob if you want your data to be unloaded"""
 
     def __init__(self, job_id, callback):
@@ -1454,7 +1454,7 @@ class DataLoadingJob(Job):
 
 
 class AttributeLoadingJob(DataLoadingJob):
-    """Modify the current master process by loading the return value of a callback
+    """Modify the current main process by loading the return value of a callback
     into an object attribute.
 
     On cleanup, the attribute is deleted via del

--- a/pypipegraph/ppg_exceptions.py
+++ b/pypipegraph/ppg_exceptions.py
@@ -64,6 +64,6 @@ class JobDiedException(PyPipeGraphError):
 
 
 class CommunicationFailure(PyPipeGraphError):
-    """something went wrong talking to a slave"""
+    """something went wrong talking to a subordinate"""
 
     pass

--- a/pypipegraph/tests/test_pypipegraph.py
+++ b/pypipegraph/tests/test_pypipegraph.py
@@ -897,7 +897,7 @@ test_modifies_shared_global = []
 
 
 class DataLoadingJobTests(PPGPerTest):
-    def test_modifies_slave(self):
+    def test_modifies_subordinate(self):
         # global shared
         # shared = "I was the the global in the mcp"
         def load():
@@ -3171,9 +3171,9 @@ class DependencyInjectionJobTests(PPGPerTest):
         # reference different objects.
         # I'm not sure how to handle this right now though.
 
-        # I have an idea: Do JobGraphModifyingJobs in each slave, and send back just the
+        # I have an idea: Do JobGraphModifyingJobs in each subordinate, and send back just the
         # dependency data (and new job name).
-        # that way, we can still execute on any slave, and all the pointers should be
+        # that way, we can still execute on any subordinate, and all the pointers should be
         # right.
         ppg.new_pipegraph(rc_gen(), dump_graph=False)
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.